### PR TITLE
Adding new flag for the User Auth action to use with OSDJoin TS vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ UI++.VC.db
 Build
 Intermediate
 vcpkg_installed
+/.vs/UI++/v18
+/.vs

--- a/UI++/Actions/InteractiveActions.cpp
+++ b/UI++/Actions/InteractiveActions.cpp
@@ -276,6 +276,7 @@ namespace UIpp
 
 		CString domainController = GetXMLAttribute(m_actionData.pActionNode, XML_ATTRIBUTE_DOMAINCONTROLLER);
 		bool doNotFallBack = FTW::IsTrue(GetXMLAttribute(m_actionData.pActionNode, XML_ATTRIBUTE_DONOTFALLBACK, XML_ACTION_FALSE));
+		bool useForOSDJoin = FTW::IsTrue(GetXMLAttribute(m_actionData.pActionNode, XML_ATTRIBUTE_AUTH_USER_OSDJOIN, XML_ACTION_FALSE));
 
 		CDlgBase::DialogVisibilityFlags dlgFlags = CDlgBase::BuildDialogVisibilityFlags(true,
 			includeBack,
@@ -288,6 +289,7 @@ namespace UIpp
 			getGroups,
 			disableCancel,
 			doNotFallBack,
+			useForOSDJoin,
 			_tstoi(maxRetryCount));
 
 		CDlgUserAuth dlg(actionTitle, dlgFlags, m_actionData, &authdata);

--- a/UI++/Constants.h
+++ b/UI++/Constants.h
@@ -408,7 +408,7 @@ const _TCHAR* const	VAR_IPSUBNETMASK =				(_T("XIPSubnetMask"));
 const _TCHAR* const	VAR_MACADDRESS =				(_T("XMACAddress"));
 
 const _TCHAR* const	VAR_OSDJOINPASS =				(_T("OSDJoinPassword"));
-const _TCHAR* const	VAR_OSDJOINACCOUNT =	`		(_T("OSDJoinAccount"));
+const _TCHAR* const	VAR_OSDJOINACCOUNT =			(_T("OSDJoinAccount"));
 const _TCHAR* const VAR_BLACKSLASH =				(_T("\\"));
 
 const _TCHAR* const	VALUE_OSVERSION_PE =			(_T("PE"));

--- a/UI++/Constants.h
+++ b/UI++/Constants.h
@@ -203,6 +203,8 @@ const _TCHAR* const XML_ATTRIBUTE_TITLE_PROGRESS_DEF = (_T("Collecting values fr
 
 DWORD const XML_ATTRIBUTE_MAXRUNTIME_DEF =			60;
 
+const _TCHAR* const XML_ATTRIBUTE_AUTH_USER_OSDJOIN = (_T("UseForOSDJoin"));
+
 const _TCHAR* const	XML_ACTION_TYPE_USERINPUT =		(_T("Input"));
 const _TCHAR* const	XML_ACTION_TYPE_USERINFO =		(_T("Info"));
 const _TCHAR* const	XML_ACTION_TYPE_ERRORINFO =		(_T("ErrorInfo"));
@@ -404,6 +406,10 @@ const _TCHAR* const	VAR_IPADDRESS =					(_T("XIPAddress"));
 const _TCHAR* const	VAR_IPSUBNET =					(_T("XIPSubnet"));
 const _TCHAR* const	VAR_IPSUBNETMASK =				(_T("XIPSubnetMask"));
 const _TCHAR* const	VAR_MACADDRESS =				(_T("XMACAddress"));
+
+const _TCHAR* const	VAR_OSDJOINPASS =				(_T("OSDJoinPassword"));
+const _TCHAR* const	VAR_OSDJOINACCOUNT =	`		(_T("OSDJoinAccount"));
+const _TCHAR* const VAR_BLACKSLASH =				(_T("\\"));
 
 const _TCHAR* const	VALUE_OSVERSION_PE =			(_T("PE"));
 const _TCHAR* const	VALUE_OSVERSION_NT =			(_T("NT"));

--- a/UI++/Dialogs/DlgUserAuth.cpp
+++ b/UI++/Dialogs/DlgUserAuth.cpp
@@ -111,18 +111,6 @@ void CDlgUserAuth::OnBnClickedNextaction()
 
 		m_actionData.pLdap->Authenticate(pUser, pPass, pDom, pDC, m_pData->m_doNotFallback);
 
-		if (m_pData->m_useForOSDJoin == true)
-		{
-			//I am not very good with C++ - there is probably a better way to do this.
-			_tcscat_s(pOSDUser, MAX_STRING_LENGTH, pDom);
-			_tcscat_s(pOSDUser, MAX_STRING_LENGTH, VAR_BLACKSLASH);
-			_tcscat_s(pOSDUser, MAX_STRING_LENGTH, pUser);
-			CTSEnv::Instance().Set(m_actionData.pCMLog, VAR_OSDJOINACCOUNT, pOSDUser, true);
-			CTSEnv::Instance().Set(m_actionData.pCMLog, VAR_OSDJOINPASS, pPass, FALSE);
-		}
-
-		SecureZeroMemory(pPass, sizeof(TCHAR) * (MAX_STRING_LENGTH - 1));
-
 		m_actionData.pCMLog->WriteMsg(FTWCMLOG::CCMLog::MsgType::Info,
 			AfxGetThread()->m_nThreadID, __TFILE__, __LINE__,
 			FTW::FormatResourceString(IDS_LOGMSG_USERAUTH, pUser, pDom, ldap_err2string(LDAP_SUCCESS), pCount));
@@ -162,7 +150,17 @@ void CDlgUserAuth::OnBnClickedNextaction()
 								
 					if (groupMembershipOK && m_pData->m_getGroups)
 						CTSEnv::Instance().Set(m_actionData.pCMLog, VAR_AUTHUSERGROUPS, m_actionData.pLdap->ExtractGroupNamesFromAttributeList(ppAttributeVal));
-
+						if (m_pData->m_useForOSDJoin == true)
+						{
+							//I am not very good at C++ - there is probably a better way to do this.
+							_tcscpy_s(pOSDUser, MAX_STRING_LENGTH, pDom);
+							_tcscat_s(pOSDUser, MAX_STRING_LENGTH, VAR_BLACKSLASH);
+							_tcscat_s(pOSDUser, MAX_STRING_LENGTH, pUser);
+							CTSEnv::Instance().Set(m_actionData.pCMLog, VAR_OSDJOINACCOUNT, pOSDUser, true);
+							CTSEnv::Instance().Set(m_actionData.pCMLog, VAR_OSDJOINPASS, pPass, false);
+						}
+						//Have to delay the secure erase so the password can be captured for task sequence variable OSDJoinPassword
+						SecureZeroMemory(pPass, sizeof(TCHAR) * (MAX_STRING_LENGTH - 1));
 				}
 				else
 				{
@@ -180,6 +178,8 @@ void CDlgUserAuth::OnBnClickedNextaction()
 				}
 
 			}
+			
+			SecureZeroMemory(pPass, sizeof(TCHAR) * (MAX_STRING_LENGTH - 1));
 
 			if (groupMembershipOK && !m_fatalAuthError)
 			{
@@ -244,7 +244,7 @@ void CDlgUserAuth::OnBnClickedNextaction()
 	delete[] pUser;
 	delete[] pDom;
 	delete[] pCount;
-
+	delete[] pOSDUser;
 }
 
 void CDlgUserAuth::DisplayFinalError(DWORD msg)

--- a/UI++/Dialogs/DlgUserAuth.cpp
+++ b/UI++/Dialogs/DlgUserAuth.cpp
@@ -72,6 +72,7 @@ void CDlgUserAuth::OnBnClickedNextaction()
 	PTSTR pUser = new TCHAR[MAX_STRING_LENGTH];
 	PTSTR pDom = new TCHAR[MAX_STRING_LENGTH];
 	PTSTR pCount = new TCHAR[MAX_STRING_LENGTH];
+	PTSTR pOSDUser = new TCHAR[MAX_STRING_LENGTH];
 
 	int count = 0;
 
@@ -109,6 +110,16 @@ void CDlgUserAuth::OnBnClickedNextaction()
 			pDC	= m_pData->m_domainController.GetString();
 
 		m_actionData.pLdap->Authenticate(pUser, pPass, pDom, pDC, m_pData->m_doNotFallback);
+
+		if (m_pData->m_useForOSDJoin == true)
+		{
+			//I am not very good with C++ - there is probably a better way to do this.
+			_tcscat_s(pOSDUser, MAX_STRING_LENGTH, pDom);
+			_tcscat_s(pOSDUser, MAX_STRING_LENGTH, VAR_BLACKSLASH);
+			_tcscat_s(pOSDUser, MAX_STRING_LENGTH, pUser);
+			CTSEnv::Instance().Set(m_actionData.pCMLog, VAR_OSDJOINACCOUNT, pOSDUser, true);
+			CTSEnv::Instance().Set(m_actionData.pCMLog, VAR_OSDJOINPASS, pPass, FALSE);
+		}
 
 		SecureZeroMemory(pPass, sizeof(TCHAR) * (MAX_STRING_LENGTH - 1));
 

--- a/UI++/Dialogs/DlgUserAuth.h
+++ b/UI++/Dialogs/DlgUserAuth.h
@@ -14,6 +14,7 @@ struct DlgUserAuthData
 		bool getGroups = false,
 		bool disableCancel = false, 
 		bool doNotFallback = false,
+		bool useForOSDJoin = false,
 		int maxRetries = 0)
 		:	m_authorizedUserGroups(pAuthorizedUserGroups),
 			m_userAttributes(pUserattributes),
@@ -21,7 +22,8 @@ struct DlgUserAuthData
 			m_getGroups(getGroups),
 			m_disableCancel(disableCancel),
 			m_doNotFallback(doNotFallback),
-			m_maxRetries(maxRetries)
+			m_maxRetries(maxRetries),
+			m_useForOSDJoin(useForOSDJoin)
 	{};
 
 	CString m_authorizedUserGroups;
@@ -31,6 +33,7 @@ struct DlgUserAuthData
 	bool m_getGroups;
 	bool m_disableCancel;
 	bool m_doNotFallback;
+	bool m_useForOSDJoin;
 };
 
 typedef DlgUserAuthData* PDlgUserAuthData;


### PR DESCRIPTION
This patch adds an additional optional flag to the UserAuth action - "UseforOSDJoin".  When enabled, this will take the authenticated domain, username, and password and assign the appropriate values to the two standard Task Sequence variables "OSDJoinAccount" and "OSDJoinPassword" These can then be used by OSD as the credentials to automatically join the device to the AD domain.

**Sample usage:**
`<Action Type="UserAuth" Name="User Authentication" Title="Please authenticate to continue." Domain="example.com" Group="OSDUsers" GetGroups="True" MaxRetryCount="5" DisableCancel="True" DoNotFallback="True" UseForOSDJoin="True"></Action>
`

**NOTE:** This does have the side effect of storing the password as plaintext via the TS var, but that's _always_ been an issue with the OSDJoin variables. Regardless, I felt that this was worth clarifying.

**Disclaimer:** I don't usually program, I usually just sysadministrate and I have not written any C++ code in like 20 years. That said, the contributed code does compile and does what it is supposed to, so I clearly remembered something from my CS classes. My apologies if I did something wrong, especially with GitHub stuff as I have very little experience with it.